### PR TITLE
Add support Linux 5.11.0 and more

### DIFF
--- a/ax88179_178a.c
+++ b/ax88179_178a.c
@@ -1033,7 +1033,9 @@ static const struct net_device_ops ax88179_netdev_ops = {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 39)
 	.ndo_set_features	= ax88179_set_features,
 #endif
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
+	.ndo_get_stats64	= dev_get_tstats64,
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
 	.ndo_get_stats64	= usbnet_get_stats64,
 #endif
 };


### PR DESCRIPTION
Add support for Linux kernel version 5.11.0 and more, which deprecated usbnet_get_stats64() function and used dev_get_tstats64() function to instead.